### PR TITLE
Make a new arg `lockfile` for Dockerfile generation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # vetiver (development version)
 
+* The lockfile created by `vetiver_write_docker()` can now be named via the argument `lockfile`, and its default is `vetiver_renv.lock` (#100).
+
 # vetiver 0.1.5
 
 * Add functions for model monitoring (#92).

--- a/man/vetiver_write_docker.Rd
+++ b/man/vetiver_write_docker.Rd
@@ -8,6 +8,7 @@ vetiver_write_docker(
   vetiver_model,
   plumber_file = "plumber.R",
   path = ".",
+  lockfile = "vetiver_renv.lock",
   rspm = TRUE,
   port = 8000
 )
@@ -20,6 +21,9 @@ vetiver_write_docker(
 
 \item{path}{A path to write the Dockerfile and \code{renv.lock} lockfile,
 capturing the model's package dependencies. Defaults to the working directory.}
+
+\item{lockfile}{The generated lockfile in \code{path}. Defaults to
+\code{"vetiver_renv.lock"}.}
 
 \item{rspm}{A logical to use the
 \href{https://packagemanager.rstudio.com/}{RStudio Public Package Manager} for
@@ -34,8 +38,8 @@ The content of the Dockerfile, invisibly.
 }
 \description{
 After creating a Plumber file with \code{\link[=vetiver_write_plumber]{vetiver_write_plumber()}}, use
-\code{vetiver_write_docker()} to create a Dockerfile plus an \code{renv.lock} file
-for a pinned \code{\link[=vetiver_model]{vetiver_model()}}.
+\code{vetiver_write_docker()} to create a Dockerfile plus a \code{vetiver_renv.lock}
+file for a pinned \code{\link[=vetiver_model]{vetiver_model()}}.
 }
 \examples{
 \dontshow{if (interactive() || identical(Sys.getenv("IN_PKGDOWN"), "true")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}

--- a/tests/testthat/_snaps/write-docker.md
+++ b/tests/testthat/_snaps/write-docker.md
@@ -18,7 +18,7 @@
         make \
         zlib1g-dev
       
-      COPY <redacted>/renv.lock renv.lock
+      COPY vetiver_renv.lock renv.lock
       RUN Rscript -e "install.packages('renv')"
       RUN Rscript -e "renv::restore()"
       COPY <redacted>/plumber.R /opt/ml/plumber.R
@@ -44,7 +44,7 @@
         make \
         zlib1g-dev
       
-      COPY <redacted>/renv.lock renv.lock
+      COPY vetiver_renv.lock renv.lock
       RUN Rscript -e "install.packages('renv')"
       RUN Rscript -e "renv::restore()"
       COPY <redacted>/plumber.R /opt/ml/plumber.R
@@ -70,7 +70,7 @@
         libssl-dev \
         make
       
-      COPY <redacted>/renv.lock renv.lock
+      COPY vetiver_renv.lock renv.lock
       RUN Rscript -e "install.packages('renv')"
       RUN Rscript -e "renv::restore()"
       COPY <redacted>/plumber.R /opt/ml/plumber.R
@@ -97,7 +97,7 @@
         make \
         zlib1g-dev
       
-      COPY <redacted>/renv.lock renv.lock
+      COPY vetiver_renv.lock renv.lock
       RUN Rscript -e "install.packages('renv')"
       RUN Rscript -e "renv::restore()"
       COPY <redacted>/plumber.R /opt/ml/plumber.R


### PR DESCRIPTION
Closes #99 

@ggpinto Thank you so much for the feedback! 🙌  Would you like to take a look at this and see if it would fit your use case?

``` r
library(vetiver)
library(pins)
b <- board_temp(versioned = TRUE)
cars_lm <- lm(mpg ~ ., data = mtcars)
v <- vetiver_model(cars_lm, "cars_linear")
vetiver_pin_write(b, v)
#> Creating new version '20220606T221019Z-9ca24'
#> Writing to pin 'cars_linear'
#> 
#> Create a Model Card for your published model
#> • Model Cards provide a framework for transparent, responsible reporting
#> • Use the vetiver `.Rmd` template as a place to start
vetiver_write_plumber(b, "cars_linear")

vetiver_write_docker(v)
#> * Lockfile written to 'vetiver_renv.lock'.
cat(readr::read_lines("Dockerfile"), sep = "\n")
#> # Generated by the vetiver package; edit with care
#> 
#> FROM rocker/r-ver:4.2.0
#> ENV RENV_CONFIG_REPOS_OVERRIDE https://packagemanager.rstudio.com/cran/latest
#> 
#> RUN apt-get update -qq && apt-get install -y --no-install-recommends \
#>   git \
#>   libcurl4-openssl-dev \
#>   libgit2-dev \
#>   libicu-dev \
#>   libsodium-dev \
#>   libssl-dev \
#>   make
#> 
#> COPY vetiver_renv.lock renv.lock
#> RUN Rscript -e "install.packages('renv')"
#> RUN Rscript -e "renv::restore()"
#> COPY plumber.R /opt/ml/plumber.R
#> 
#> ENTRYPOINT ["R", "-e", "pr <- plumber::plumb('/opt/ml/plumber.R'); pr$run(host = '0.0.0.0', port = 8000)"]
```

<sup>Created on 2022-06-06 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>