### PR TITLE
Make pins information available to knitr chunk from output formats in YAML

### DIFF
--- a/R/dashboard.R
+++ b/R/dashboard.R
@@ -11,14 +11,12 @@
 #'  \href{http://rmarkdown.rstudio.com/flexdashboard/}{http://rmarkdown.rstudio.com/flexdashboard/}
 #'
 #' @export
-vetiver_dashboard <- function(board, name, version = NULL,
-                              ..., display_pins = TRUE) {
-
-    dashboard_dots <- rlang::list2(...)
+vetiver_dashboard <- function(pins, display_pins = TRUE, ...) {
     rlang::check_installed("flexdashboard")
-    v <- pin_read_version(board, name, version)
+    dashboard_dots <- rlang::list2(...)
 
     if (display_pins) {
+        v <- pin_read_version(pins$board, pins$name, pins$version)
         dashboard_dots <- vetiver_modify_navbar(dashboard_dots, v$metadata$url)
     }
     if (is_null(dashboard_dots$favicon)) {
@@ -26,7 +24,18 @@ vetiver_dashboard <- function(board, name, version = NULL,
         dashboard_dots <- modifyList(dashboard_dots, list(favicon = vetiver_fav))
     }
 
-    rlang::inject(flexdashboard::flex_dashboard(!!!dashboard_dots))
+    rmarkdown::output_format(,
+        knitr = rmarkdown::knitr_options(
+            opts_knit = list(vetiver_dashboard.pins = pins),
+            # require to keep flexdashboard one
+            opts_chunk = list(),
+            knit_hooks = list(),
+            opts_hooks = list(),
+            opts_template = list()
+        ),
+        pandoc = NULL,
+        base_format = rlang::inject(flexdashboard::flex_dashboard(!!!dashboard_dots))
+    )
 }
 
 


### PR DESCRIPTION
This is what we discussed related to #98 

This solution makes the pins information available in the **knitr** environment to be accessible during knitting. 

To be user friendly you could have a getter function so that a users gets the info back easily to use the same board as defined in YAML. 

````markdown
---
title: "Monitor model"
output: 
  vetiver::vetiver_dashboard:
    pins:
      board: !expr pins::board_local()
      name: 'hotel_rf'
      version: NULL
    storyboard: true
    source_code: 'https://vetiver.rstudio.com/'
    display_pins: true
---

```{r}
get_vetiver_dashboard_pins <- function() {
    knitr::opts_knit$get("vetiver_dashboard.pins")
}
```

```{r}
pins <- get_vetiver_dashboard_pins()
v <- vetiver_pin_read(pins$board, pins$name, version = pins$version)
```
````

This is the easiest solution for now. Other ones I explored may need a small update (non impactful) to **flexdashboard** so that navbar is created later in the render process. I can detail the different options I explored if you want. 

Created as draft to let you decide to just take inspiration or merge in your other PR branch. It does not meant to be complete, some checks need to be added probably (on `pins` content for example), but you can do that once you settle on a solution