### PR TITLE
Switch default for `overwrite` to `FALSE`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * The lockfile created by `vetiver_write_docker()` can now be named via the argument `lockfile`, and its default is `vetiver_renv.lock` (#100).
 
+* Switched the default for `overwrite` in `vetiver_pin_metrics()` from `TRUE` to `FALSE`. Using `FALSE` is a better choice for interactive use while `TRUE` is probably the right choice for reports or dashboards that are executed on a schedule (#104).
+
 # vetiver 0.1.5
 
 * Add functions for model monitoring (#92).

--- a/R/monitor.R
+++ b/R/monitor.R
@@ -20,10 +20,10 @@
 #' `vetiver_compute_metrics()`.
 #' @param metrics_pin_name Pin name for where the *metrics* are stored (as
 #' opposed to where the model object is stored with [vetiver_pin_write()]).
-#' @param overwrite If `TRUE` (the default), overwrite any metrics for dates
-#' that exist both in the existing pin and new metrics with the _new_ values.
-#' If `FALSE`, error when the new metrics contain overlapping dates with the
-#' existing pin.
+#' @param overwrite If `FALSE` (the default), error when the new metrics contain
+#' overlapping dates with the existing pin.If `TRUE`, overwrite any metrics for
+#' dates that exist both in the existing pin and new metrics with the _new_
+#' values.
 #' @param .index The variable in `df_metrics` containing the aggregated dates
 #' or date-times (from `time_var` in `data`). Defaults to `.index`.
 #' @param .estimate The variable in `df_metrics` containing the metric estimate.
@@ -41,10 +41,11 @@
 #' may end up with dates in your new metrics (like `new_metrics` in the example)
 #' that are the same as dates in your existing aggregated metrics (like
 #' `original_metrics` in the example). This can happen if you need to re-run a
-#' monitoring report because something failed. With `overwrite = TRUE` (the
-#' default), `vetiver_pin_metrics()` will replace such metrics with the new
-#' values. With `overwrite = FALSE`, `vetiver_pin_metrics()` will error when
-#' there are overlapping dates.
+#' monitoring report because something failed. With `overwrite = FALSE` (the
+#' default), `vetiver_pin_metrics()` will error when there are overlapping
+#' dates. With `overwrite = TRUE`, `vetiver_pin_metrics()` will replace such
+#' metrics with the new values. You probably want `FALSE` for interactive use
+#' and `TRUE` for dashboards or reports that run on a schedule.
 #'
 #' For arguments used more than once in your monitoring dashboard,
 #' such as `date_var`, consider using
@@ -128,7 +129,7 @@ vetiver_pin_metrics <- function(board,
                                 df_metrics,
                                 metrics_pin_name,
                                 .index = .index,
-                                overwrite = TRUE) {
+                                overwrite = FALSE) {
     .index <- enquo(.index)
     .index <- eval_select_one(.index, df_metrics, "date_var")
     new_dates <- unique(df_metrics[[.index]])

--- a/man/vetiver_compute_metrics.Rd
+++ b/man/vetiver_compute_metrics.Rd
@@ -26,7 +26,7 @@ vetiver_pin_metrics(
   df_metrics,
   metrics_pin_name,
   .index = .index,
-  overwrite = TRUE
+  overwrite = FALSE
 )
 
 vetiver_plot_metrics(
@@ -38,8 +38,8 @@ vetiver_plot_metrics(
 )
 }
 \arguments{
-\item{data}{A \code{data.frame} containing the \code{truth} and \code{estimate}
-columns and any columns specified by \code{...}.}
+\item{data}{A \code{data.frame} containing the columns specified by \code{truth},
+\code{estimate}, and \code{...}.}
 
 \item{date_var}{The column in \code{data} containing dates or date-times for
 monitoring, to be aggregated with \code{.period}}
@@ -58,7 +58,7 @@ broken into:
 \item{truth}{The column identifier for the true results (that
 is \code{numeric} or \code{factor}). This should be an unquoted column name
 although this argument is passed by expression and support
-\link[rlang:nse-force]{quasiquotation} (you can unquote column
+\link[rlang:topic-inject]{quasiquotation} (you can unquote column
 names).}
 
 \item{estimate}{The column identifier for the predicted results
@@ -114,10 +114,10 @@ opposed to where the model object is stored with \code{\link[=vetiver_pin_write]
 \item{.index}{The variable in \code{df_metrics} containing the aggregated dates
 or date-times (from \code{time_var} in \code{data}). Defaults to \code{.index}.}
 
-\item{overwrite}{If \code{TRUE} (the default), overwrite any metrics for dates
-that exist both in the existing pin and new metrics with the \emph{new} values.
-If \code{FALSE}, error when the new metrics contain overlapping dates with the
-existing pin.}
+\item{overwrite}{If \code{FALSE} (the default), error when the new metrics contain
+overlapping dates with the existing pin.If \code{TRUE}, overwrite any metrics for
+dates that exist both in the existing pin and new metrics with the \emph{new}
+values.}
 
 \item{.estimate}{The variable in \code{df_metrics} containing the metric estimate.
 Defaults to \code{.estimate}.}
@@ -150,10 +150,11 @@ Sometimes when you monitor a model at a given time aggregation, you
 may end up with dates in your new metrics (like \code{new_metrics} in the example)
 that are the same as dates in your existing aggregated metrics (like
 \code{original_metrics} in the example). This can happen if you need to re-run a
-monitoring report because something failed. With \code{overwrite = TRUE} (the
-default), \code{vetiver_pin_metrics()} will replace such metrics with the new
-values. With \code{overwrite = FALSE}, \code{vetiver_pin_metrics()} will error when
-there are overlapping dates.
+monitoring report because something failed. With \code{overwrite = FALSE} (the
+default), \code{vetiver_pin_metrics()} will error when there are overlapping
+dates. With \code{overwrite = TRUE}, \code{vetiver_pin_metrics()} will replace such
+metrics with the new values. You probably want \code{FALSE} for interactive use
+and \code{TRUE} for dashboards or reports that run on a schedule.
 
 For arguments used more than once in your monitoring dashboard,
 such as \code{date_var}, consider using

--- a/tests/testthat/test-monitor.R
+++ b/tests/testthat/test-monitor.R
@@ -66,14 +66,14 @@ describe("vetiver_pin_metrics()", {
     it("fails without existing pin", {
         b <- pins::board_temp()
         expect_snapshot_error(
-            vetiver_pin_metrics(b, df_metrics, "metrics1")
+            vetiver_pin_metrics(b, df_metrics, "metrics1", overwrite = TRUE)
         )
     })
     it("fails with `overwrite = FALSE`", {
         b <- pins::board_temp()
         pins::pin_write(b, df_metrics, "metrics2")
         expect_snapshot_error(
-            vetiver_pin_metrics(b, df_metrics, "metrics2", overwrite = FALSE)
+            vetiver_pin_metrics(b, df_metrics, "metrics2")
         )
     })
     it("can update metrics", {
@@ -88,7 +88,7 @@ describe("vetiver_pin_metrics()", {
             .estimate = c(3.0, 0.7, 2.0)
 
         )
-        res2 <- vetiver_pin_metrics(b, new_metrics, "metrics3")
+        res2 <- vetiver_pin_metrics(b, new_metrics, "metrics3", overwrite = TRUE)
         expect_equal(
             pins::pin_read(b, "metrics3"),
             dplyr::arrange(vctrs::vec_rbind(df_metrics, new_metrics), .index)


### PR DESCRIPTION
Closes #102 

When we show an example dashboard, we will now use `overwrite = TRUE` when using this function. The default `overwrite = FALSE` is the better choice for interactive use.