### PR TITLE
Use call in error message for dashboard

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,7 @@ Imports:
     rapidoc,
     readr (>= 1.4.0),
     renv,
-    rlang,
+    rlang (>= 1.0.0),
     tibble,
     vctrs,
     withr

--- a/R/dashboard.R
+++ b/R/dashboard.R
@@ -33,8 +33,7 @@ vetiver_dashboard <- function(pins, display_pins = TRUE, ...) {
     v <- dashboard_read_version(
         pins$board,
         pins$name,
-        pins$version,
-        call = caller_env()
+        pins$version
     )
 
     if (display_pins && !is_null(v$metadata$url)) {
@@ -60,15 +59,17 @@ vetiver_dashboard <- function(pins, display_pins = TRUE, ...) {
 }
 
 
-dashboard_read_version <- function(board, name, version, call) {
+dashboard_read_version <- function(board, name, version, call = rlang::caller_env()) {
     if (!pins::pin_exists(board, name)) {
-        rlang::abort(c(
-            glue("The pin {glue::double_quote(name)} does not exist on your board"),
-            "*" = "Check the `pins` params in your dashboard YAML",
-            "i" = glue("To knit the example vetiver monitoring dashboard, \\
+        rlang::abort(
+            c(
+                glue("The pin {glue::double_quote(name)} does not exist on your board"),
+                "*" = "Check the `pins` params in your dashboard YAML",
+                "i" = glue("To knit the example vetiver monitoring dashboard, \\
                        execute `vetiver::pin_example_kc_housing_model()` to \\
                        set up demo model and metrics pins")
-        ))
+            ),
+            call = call)
     }
     if (board$versioned) {
         if (is_null(version)) {

--- a/R/ptype.R
+++ b/R/ptype.R
@@ -63,11 +63,12 @@ vetiver_create_ptype <- function(model, save_ptype, ...) {
     ptype
 }
 
-check_ptype_data <- function(dots) {
+check_ptype_data <- function(dots, call = rlang::caller_env()) {
     if (!rlang::has_name(dots, "ptype_data")) {
         abort(c("No `ptype_data` available to create an input data prototype",
                 "Pass at least one row of training features as `ptype_data`",
-                "See the documentation for `vetiver_ptype()`"))
+                "See the documentation for `vetiver_ptype()`"),
+              call = call)
     }
 }
 

--- a/tests/testthat/_snaps/api.md
+++ b/tests/testthat/_snaps/api.md
@@ -2,7 +2,8 @@
 
     Code
       p <- pr() %>% vetiver_pr_predict(v)
-    Warning <lifecycle_warning_deprecated>
+    Condition
+      Warning:
       `vetiver_pr_predict()` was deprecated in vetiver 0.1.2.
       Please use `vetiver_api()` instead.
 

--- a/tests/testthat/_snaps/choose-version.md
+++ b/tests/testthat/_snaps/choose-version.md
@@ -2,7 +2,8 @@
 
     Code
       p <- choose_version(p)
-    Warning <rlang_warning>
+    Condition
+      Warning:
       Pinned vetiver model has no active version and no datetime on versions
       * Do you need to check your pinned model?
       * Using version 4500

--- a/tests/testthat/_snaps/create-ptype.md
+++ b/tests/testthat/_snaps/create-ptype.md
@@ -2,6 +2,7 @@
 
     Code
       vetiver_create_ptype(cars_lm, "potato")
-    Error <rlang_error>
-      The `save_ptype` argument must be TRUE, FALSE, or a dataframe.
+    Condition
+      Error in `vetiver_create_ptype()`:
+      ! The `save_ptype` argument must be TRUE, FALSE, or a dataframe.
 

--- a/tests/testthat/_snaps/dashboard.md
+++ b/tests/testthat/_snaps/dashboard.md
@@ -1,6 +1,10 @@
 # vetiver_dashboard(): errors without pin
 
-    The pin "seattle_rf" does not exist on your board
-    • Check the `pins` params in your dashboard YAML
-    ℹ To knit the example vetiver monitoring dashboard, execute `vetiver::pin_example_kc_housing_model()` to set up demo model and metrics pins
+    Code
+      vetiver_dashboard(pins = list(board = b, name = "seattle_rf", version = NULL))
+    Condition
+      Error in `vetiver_dashboard()`:
+      ! The pin "seattle_rf" does not exist on your board
+      • Check the `pins` params in your dashboard YAML
+      ℹ To knit the example vetiver monitoring dashboard, execute `vetiver::pin_example_kc_housing_model()` to set up demo model and metrics pins
 

--- a/tests/testthat/_snaps/predict.md
+++ b/tests/testthat/_snaps/predict.md
@@ -11,8 +11,9 @@
 
     Code
       predict(endpoint, mtcars[, 2:4])
-    Error <rlang_error>
-      Failed to predict: Error in `hardhat::scream()`:
+    Condition
+      Error in `predict()`:
+      ! Failed to predict: Error in `hardhat::scream()`:
       ! Can't convert from `data` <tbl_df<
         cyl : integer
         disp: double
@@ -26,7 +27,8 @@
 
     Code
       predict(endpoint, mtcars[, 3:5])
-    Error <rlang_error>
-      Failed to predict: Error in `glubort()`:
+    Condition
+      Error in `predict()`:
+      ! Failed to predict: Error in `glubort()`:
       ! The following required columns are missing: 'cyl'.
 

--- a/tests/testthat/_snaps/ranger.md
+++ b/tests/testthat/_snaps/ranger.md
@@ -11,8 +11,9 @@
 
     Code
       vetiver_model(cars_rf, "cars3")
-    Error <rlang_error>
-      No `ptype_data` available to create an input data prototype
+    Condition
+      Error in `vetiver_ptype()`:
+      ! No `ptype_data` available to create an input data prototype
       * Pass at least one row of training features as `ptype_data`
       * See the documentation for `vetiver_ptype()`
 

--- a/tests/testthat/test-dashboard.R
+++ b/tests/testthat/test-dashboard.R
@@ -28,8 +28,9 @@ describe("vetiver_dashboard()", {
 
     it("errors without pin", {
         b <- pins::board_temp()
-        expect_snapshot_error(
-            vetiver_dashboard(pins = list(board = b, name = "seattle_rf", version = NULL))
+        expect_snapshot(
+            vetiver_dashboard(pins = list(board = b, name = "seattle_rf", version = NULL)),
+            error = TRUE
         )
     })
 


### PR DESCRIPTION
Related to #98

This PR corrects how the call is used in the error message for the `vetiver_dashboard()` function.