### PR TITLE
Add ptype names and types to the metadata

### DIFF
--- a/R/vetiver-model.R
+++ b/R/vetiver-model.R
@@ -55,6 +55,12 @@ vetiver_model <- function(model,
     }
     ptype <- vetiver_create_ptype(model, save_ptype, ...)
     metadata <- vetiver_create_meta(model, metadata)
+    if (!is.null(ptype)) {
+      if ("ptype" %in% names(metadata$user)) {
+        abort("ptype is a reserved metadata name, used for ptype metadata, please use a different name")
+      }
+      metadata$user$ptype <- lapply(ptype, class)
+    }
     model <- vetiver_prepare_model(model)
 
     new_vetiver_model(

--- a/tests/testthat/test-pin-read-write.R
+++ b/tests/testthat/test-pin-read-write.R
@@ -46,7 +46,8 @@ test_that("default metadata for model", {
     v <- vetiver_model(cars_lm, "cars2")
     vetiver_pin_write(b, v)
     meta <- pin_meta(b, "cars2")
-    expect_equal(meta$user, list())
+    expect_equal(meta$user, list(ptype = list(cyl = 'numeric',
+                                              disp = 'numeric')))
     expect_equal(meta$description, "An OLS linear regression model")
 })
 
@@ -57,8 +58,18 @@ test_that("user can supply metadata for model", {
                        metadata = list(metrics = 1:10))
     vetiver_pin_write(b, v)
     meta <- pin_meta(b, "cars3")
-    expect_equal(meta$user, list(metrics = 1:10))
+    expect_equal(meta$user, list(metrics = 1:10,
+                                 ptype = list(cyl = 'numeric',
+                                              disp = 'numeric')))
     expect_equal(meta$description, "lm model for mtcars")
+})
+
+test_that("user cannot use reserved ptype name for metadata", {
+    b <- board_temp()
+    expect_error(vetiver_model(cars_lm, "cars3",
+                               description = "lm model for mtcars",
+                               metadata = list(ptype = T)),
+                 "ptype is a reserved metadata name, used for ptype metadata, please use a different name")
 })
 
 test_that("can read a pinned model", {


### PR DESCRIPTION
With the model registry (board of pinned models), the number one most requested feature from my data science team is metadata about model input parameters.

# Workaround 1

With current `vetiver`, it is possible by running the below code with every pinned model's `rds` file in the board:

```r
lapply(ptype, class)
```

but having to load the `.rds` file for every model (some very large due to large models) in order to get the `ptype` object is expensive and slow.

# Workaround 2

We can ask data scientists to replace:

```r
v <- vetiver_model(model)
```

with:
```r
v <- vetiver_model(model)
v$metadata$user$ptype <- lapply(v$ptype, class)
```

but the usability/inconsistency of it is a bit confusing - "isn't ptype already included? do we need to specify the ptype? why is description already in metadata but not ptype?" etc. The `lapply` code and use of `class` is also only understood by those with a more advanced understanding of R typing. Would it be better to have it included in the `vetiver` library?

# Proposal

This PR includes metadata about ptype when the ptype is included. This means that with the following code:

```
v <- vetiver_model(model)
```

it will include ptype along with their metadata, by default.