### PR TITLE
check rmarkdown in tests

### DIFF
--- a/tests/testthat/test-dashboard.R
+++ b/tests/testthat/test-dashboard.R
@@ -1,3 +1,5 @@
+skip_if_not_installed("rmarkdown", minimum_version = "2.12")
+
 test_that("templates exist", {
     expect_equal(
         rmarkdown::available_templates("vetiver"),


### PR DESCRIPTION
Dashboard tests fail if `rmarkdown` package not installed. The `rmarkdown::available_templates()` method was [added in v2.12](https://github.com/rstudio/rmarkdown/releases/tag/v2.12). This adds a skip condition.

Nothing urgent.