### PR TITLE
Pass the dots to `pin_write()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # vetiver (development version)
 
+* Now pass the dots for writing a pin through to vetiver allowing, for example, `vetiver_pin_write(b, v, access_type = "all")` on RStudio Connect (#121).
+
 # vetiver 0.1.6
 
 * The lockfile created by `vetiver_write_docker()` can now be named via the argument `lockfile`, and its default is `vetiver_renv.lock` (#100).

--- a/R/pin-read-write.R
+++ b/R/pin-read-write.R
@@ -4,8 +4,8 @@
 #' along with an input prototype for new data and other model metadata. Use
 #' `vetiver_pin_read()` to retrieve that pinned object.
 #'
-#' @inheritParams vetiver_api
 #' @inheritParams pins::pin_read
+#' @inheritParams vetiver_api
 #'
 #' @details These functions read and write a [vetiver_model()] pin on the
 #' specified `board` containing the model object itself and other elements
@@ -32,7 +32,7 @@
 #' pin_versions(model_board, "cars_linear")
 #'
 #' @export
-vetiver_pin_write <- function(board, vetiver_model) {
+vetiver_pin_write <- function(board, vetiver_model, ...) {
     pins::pin_write(
         board = board,
         x = list(model = vetiver_model$model,
@@ -42,7 +42,8 @@ vetiver_pin_write <- function(board, vetiver_model) {
         type = "rds",
         description = vetiver_model$description,
         metadata = vetiver_model$metadata$user,
-        versioned = vetiver_model$versioned
+        versioned = vetiver_model$versioned,
+        ...
     )
     rlang::inform(
         c("\nCreate a Model Card for your published model",

--- a/man/vetiver_pin_write.Rd
+++ b/man/vetiver_pin_write.Rd
@@ -5,7 +5,7 @@
 \alias{vetiver_pin_read}
 \title{Read and write a trained model to a board of models}
 \usage{
-vetiver_pin_write(board, vetiver_model)
+vetiver_pin_write(board, vetiver_model, ...)
 
 vetiver_pin_read(board, name, version = NULL)
 }
@@ -14,6 +14,8 @@ vetiver_pin_read(board, name, version = NULL)
 \code{\link[pins:board_url]{board_url()}} or another \code{board_} function.}
 
 \item{vetiver_model}{A deployable \code{\link[=vetiver_model]{vetiver_model()}} object}
+
+\item{...}{Additional arguments passed on to methods for a specific board.}
 
 \item{name}{Pin name.}
 


### PR DESCRIPTION
This PR addresses #118 by passing the dots from `vetiver_pin_write()` through to `pins::pin_write()`. This let you do something like:

```r
library(vetiver)
b <- pins::board_rsconnect()

cars_lm <- lm(mpg ~ ., data = mtcars)
v <- vetiver_model(cars_lm, "cars_linear")
vetiver_pin_write(b, v, access_type = "all")
```