### PR TITLE
Remove any trailing slash in `vetiver_endpoint()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -75,4 +75,4 @@ Config/Needs/website: tidyverse/tidytemplate, rstudio/connectapi
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.0
+RoxygenNote: 7.2.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # vetiver (development version)
 
+* Trailing slashes are now removed from `vetiver_endpoint()` (#134).
+
 # vetiver 0.1.7
 
 * Now pass the dots for writing a pin through to vetiver allowing, for example, `vetiver_pin_write(b, v, access_type = "all")` on RStudio Connect (#121, #122).

--- a/R/endpoint.R
+++ b/R/endpoint.R
@@ -45,11 +45,12 @@ predict.vetiver_endpoint <- function(object, new_data, ...) {
 #' @return A new `vetiver_endpoint` object
 #'
 #' @examples
-#' vetiver_endpoint("https://colorado.rstudio.com/rsc/biv_svm_api/predict")
+#' vetiver_endpoint("https://colorado.rstudio.com/rsc/seattle-housing/predict")
 #'
 #' @export
 vetiver_endpoint <- function(url) {
     url <- as.character(url)
+    url <- gsub("/$", "", url)
     new_vetiver_endpoint(url)
 }
 

--- a/man/vetiver_endpoint.Rd
+++ b/man/vetiver_endpoint.Rd
@@ -18,6 +18,6 @@ HTTP calls are made until you actually
 \code{\link[=predict.vetiver_endpoint]{predict()}} with your endpoint.
 }
 \examples{
-vetiver_endpoint("https://colorado.rstudio.com/rsc/biv_svm_api/predict")
+vetiver_endpoint("https://colorado.rstudio.com/rsc/seattle-housing/predict")
 
 }


### PR DESCRIPTION
Closes #120 

I spent some time looking around for options to validate that a string is a URL and it doesn't seem like I have many options other [than a regular expression](https://rex.r-lib.org/articles/url_parsing.html) (or making a HTTP call). I think I will wait on this and see if it's a common problem people run into.