### PR TITLE
Better strategy for identifying system reqs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,6 +38,7 @@ Imports:
     vctrs,
     withr
 Suggests:
+    arrow,
     callr,
     caret,
     covr,

--- a/R/write-docker.R
+++ b/R/write-docker.R
@@ -60,15 +60,16 @@ vetiver_write_docker <- function(vetiver_model,
 
     pkgs <- unique(c(docker_pkgs, vetiver_model$metadata$required_pkgs))
     pkgs <- setdiff(pkgs, drop_pkgs)
-    renv::snapshot(
-        project = path,
-        lockfile = lockfile,
-        packages = pkgs,
-        prompt = FALSE,
-        force = TRUE
-    )
+    lockfile_pkgs <-
+        renv::snapshot(
+            project = path,
+            lockfile = lockfile,
+            packages = pkgs,
+            prompt = FALSE,
+            force = TRUE
+        )
     plumber_file <- fs::path_rel(plumber_file)
-    sys_reqs <- glue_sys_reqs(pkgs)
+    sys_reqs <- glue_sys_reqs(names(lockfile_pkgs$Packages))
     copy_renv <- glue("COPY {lockfile} renv.lock")
     copy_plumber <- glue("COPY {plumber_file} /opt/ml/plumber.R")
     expose <- ifelse(expose, glue("EXPOSE {port}"), "")


### PR DESCRIPTION
Closes #150 

I couldn't reproduce any problems with the existing strategy because RSPM knows how to find system requirements for packages including dependencies, but this is probably a better strategy in case any weird edge cases or problems come up.