### PR TITLE
Fix how `vetiver_ptype()` works for models with interactions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Now vendor renv directly in package (#157).
 
+* Fixed how `vetiver_ptype()` finds predictors for models (`lm()` and `glm()`) with interactions (#160).
+
 # vetiver 0.1.8
 
 * Trailing slashes are now removed from `vetiver_endpoint()` (#134).

--- a/R/lm.R
+++ b/R/lm.R
@@ -13,7 +13,7 @@ vetiver_prepare_model.lm <- function(model) {
 #' @rdname vetiver_create_ptype
 #' @export
 vetiver_ptype.lm <- function(model, ...) {
-    pred_names <- attr(model$terms, "term.labels")
+    pred_names <- preds_lm_ish(model)
     ptype <- vctrs::vec_ptype(model$model[pred_names])
     tibble::as_tibble(ptype)
 }

--- a/R/ptype.R
+++ b/R/ptype.R
@@ -72,3 +72,32 @@ check_ptype_data <- function(dots, call = rlang::caller_env()) {
     }
 }
 
+
+preds_lm_ish <- function(model) {
+    .terms <- terms(model)
+    terms_matrix <- attr(.terms, "factors")
+    terms_names <- colnames(terms_matrix)
+    terms_exprs <- parse_exprs(terms_names)
+    has_interactions <- map_lgl(terms_exprs, expr_contains, what = as.name(":"))
+    terms_names[!has_interactions]
+}
+
+expr_contains <- function(expr, what) {
+    switch(typeof(expr),
+           symbol = identical(expr, what),
+           call = call_contains(expr, what),
+           language = call_contains(expr, what),
+           FALSE
+    )
+}
+
+call_contains <- function(expr, what) {
+    if (length(expr) == 0L) {
+        abort("Internal error, `expr` should be at least length 1.")
+    }
+
+    # Recurse into elements
+    contains <- map_lgl(expr, expr_contains, what = what)
+    any(contains)
+}
+

--- a/R/vetiver-package.R
+++ b/R/vetiver-package.R
@@ -18,7 +18,8 @@ NULL
 #' @export
 generics::augment
 
-globalVariables(c("pr", ".metric", ".pred", "price", "tidy", "term", "estimate"))
+globalVariables(c("pr", ".metric", ".pred", "price", "tidy",
+                  "term", "estimate", "terms"))
 
 ## to avoid NOTE about "All declared Imports should be used."
 rapidoc_function_for_note <- function() {

--- a/tests/testthat/_snaps/glm.md
+++ b/tests/testthat/_snaps/glm.md
@@ -7,7 +7,7 @@
       -- cars_glm - <butchered_glm> model for deployment 
       A generalized linear model (gaussian family, identity link) using 10 features
 
-# create plumber.R for xgboost
+# create plumber.R for glm
 
     Code
       cat(readr::read_lines(tmp), sep = "\n")

--- a/tests/testthat/test-create-ptype.R
+++ b/tests/testthat/test-create-ptype.R
@@ -23,6 +23,14 @@ test_that("ptype = FALSE", {
     )
 })
 
+test_that("ptype for model with interactions", {
+    cars_interaction <- lm(mpg ~ cyl * vs + disp, data = mtcars)
+    expect_equal(
+        vetiver_create_ptype(cars_interaction, TRUE),
+        vctrs::vec_slice(tibble::as_tibble(mtcars[, c(2, 8, 3)]), 0)
+    )
+})
+
 test_that("custom ptype", {
     expect_equal(
         vetiver_create_ptype(cars_lm, mtcars[3:10, 2:3]),

--- a/tests/testthat/test-glm.R
+++ b/tests/testthat/test-glm.R
@@ -54,7 +54,7 @@ test_that("default OpenAPI spec", {
 
 })
 
-test_that("create plumber.R for xgboost", {
+test_that("create plumber.R for glm", {
     skip_on_cran()
     b <- board_folder(path = tmp_dir)
     vetiver_pin_write(b, v)
@@ -63,6 +63,15 @@ test_that("create plumber.R for xgboost", {
     expect_snapshot(
         cat(readr::read_lines(tmp), sep = "\n"),
         transform = redact_vetiver
+    )
+})
+
+
+test_that("ptype for glm with interactions", {
+    cars_interaction <- glm(mpg ~ cyl * vs + disp, data = mtcars)
+    expect_equal(
+        vetiver_create_ptype(cars_interaction, TRUE),
+        vctrs::vec_slice(tibble::as_tibble(mtcars[, c(2, 8, 3)]), 0)
     )
 })
 


### PR DESCRIPTION
Closes #158 

This uses the approach that hardhat took in tidymodels/hardhat#175 to identify when a model has any interactions:

``` r
library(vetiver)

cars_lm <- lm(mpg ~ cyl*gear + disp, data = mtcars)
vetiver_ptype(cars_lm)
#> # A tibble: 0 × 3
#> # … with 3 variables: cyl <dbl>, gear <dbl>, disp <dbl>
```

<sup>Created on 2022-11-14 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>