### PR TITLE
Change `NA` handling in JSON conversion

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 * New function `vetiver_prepare_docker()` creates all necessary files to deploy a basic vetiver model via Docker (#165).
 
+* Fixed a bug in handling all-`NA` columns when predicting on a `vetiver_endpoint()` (#169).
+
 # vetiver 0.1.8
 
 * Trailing slashes are now removed from `vetiver_endpoint()` (#134).

--- a/R/endpoint.R
+++ b/R/endpoint.R
@@ -19,7 +19,7 @@
 #'
 predict.vetiver_endpoint <- function(object, new_data, ...) {
     rlang::check_installed(c("jsonlite", "httr"))
-    data_json <- jsonlite::toJSON(new_data)
+    data_json <- jsonlite::toJSON(new_data, na = "string")
     ret <- httr::POST(object$url, ..., body = data_json)
     resp <- httr::content(ret, "text", encoding = "UTF-8")
     resp <- jsonlite::fromJSON(resp)

--- a/tests/testthat/test-predict.R
+++ b/tests/testthat/test-predict.R
@@ -33,6 +33,21 @@ test_that("can predict on basic vetiver router", {
     expect_equal(ncol(aug), 3)
 })
 
+test_that("can predict with single or NA values", {
+    endpoint <- vetiver_endpoint(paste0(root_path, ":", port, "/predict"))
+
+    preds1 <- predict(endpoint, mtcars[10, 2:3])
+    expect_s3_class(preds1, "tbl_df")
+    expect_equal(nrow(preds1), 1)
+    expect_equal(ncol(preds1), 1)
+
+    preds2 <- predict(endpoint, data.frame(cyl = c(NA_real_, NA_real_),
+                                          disp = c(100, 200)))
+    expect_s3_class(preds2, "tbl_df")
+    expect_equal(nrow(preds2), 2)
+    expect_equal(ncol(preds2), 1)
+})
+
 test_that("get correct errors", {
     endpoint <- vetiver_endpoint(paste0(root_path, ":", port, "/predict"))
     expect_snapshot(predict(endpoint, mtcars[, 2:4]), error = TRUE)


### PR DESCRIPTION
Closes #167 

As show in the above issue ⤴️ we had a problem with how all-`NA` columns were handled in `predict.vetiver_endpoint`. With this change, `NA` values are stored as strings in the JSON passed over in the request body. The test shows how we can now predict with all-`NA` columns, and the example with xgboost now works.