### PR TITLE
Ignore ranger before R 4.1.0

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -48,7 +48,11 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck, any::cpp11, any::progress
+          extra-packages:
+            any::rcmdcheck,
+            any::cpp11,
+            any::progress,
+            ranger=?ignore-before-r=4.1.0
           needs: check
 
       - name: Install Miniconda & Tensorflow

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -50,8 +50,6 @@ jobs:
         with:
           extra-packages:
             any::rcmdcheck,
-            any::cpp11,
-            any::progress,
             ranger=?ignore-before-r=4.1.0
           needs: check
 


### PR DESCRIPTION
Let's try to fix the new problems installing ranger on R 4.0.x.

Gabor thinks this could be fixed in ranger itself or by putting `CXXFLAGS += -std=gnu++14` in Makevars, but let's try just ignoring it.