### PR TITLE
Fix `check_renv` behavior

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 * Moved where `required_pkgs` metadata is stored remotely, from the binary blob to plain text YAML (#176).
 
-* Added an optional renv lockfile that can be stored remotely in model metadata, with a new `check_renv` argument for reading/writing (#154).
+* Added an optional renv lockfile that can be stored remotely in model metadata, with a new `check_renv` argument for reading/writing (#154, #192).
 
 * Exposed a new `base_image` argument for creating Dockerfiles (#182).
 

--- a/R/pin-read-write.R
+++ b/R/pin-read-write.R
@@ -87,13 +87,14 @@ vetiver_pin_read <- function(board, name, version = NULL, check_renv = FALSE) {
 
     pinned <- pins::pin_read(board = board, name = name, version = version)
     meta   <- pins::pin_meta(board = board, name = name, version = version)
+    required_pkgs <- meta$user$required_pkgs %||% pinned$required_pkgs
 
     if (check_renv) {
         if (length(meta$user$renv_lock) > 0) {
             local_lockfile <-
                 renv$snapshot(
                     lockfile = NULL,
-                    packages = c(pinned$required_pkgs, "vetiver"),
+                    packages = c(required_pkgs, "vetiver"),
                     prompt = FALSE,
                     force = TRUE
                 )
@@ -107,7 +108,6 @@ vetiver_pin_read <- function(board, name, version = NULL, check_renv = FALSE) {
         }
     }
 
-    required_pkgs <- meta$user$required_pkgs %||% pinned$required_pkgs
     meta$user <- list_modify(meta$user, required_pkgs = zap(), renv_lock = zap())
     if (is_empty(meta$user)) names(meta$user) <- NULL
 

--- a/tests/testthat/test-pin-read-write.R
+++ b/tests/testthat/test-pin-read-write.R
@@ -136,7 +136,7 @@ test_that("right message for reading with `check_renv`", {
 
     vetiver_pin_write(b, v, check_renv = TRUE)
     v1 <- vetiver_pin_read(b, "cars5")
-    v2 <- vetiver_pin_read(b, "cars5", check_renv = TRUE)
+    expect_silent(v2 <- vetiver_pin_read(b, "cars5", check_renv = TRUE))
     expect_equal(v1, v2)
 
     new_lock <- renv$renv_lockfile_init(project = NULL)


### PR DESCRIPTION
Closes #189 

No incorrect message now:

``` r
library(tidymodels)
library(pins)
library(vetiver)
#> 
#> Attaching package: 'vetiver'
#> The following object is masked from 'package:tune':
#> 
#>     load_pkgs

data(bivariate)
ranger_fit <- 
    workflow(Class ~ A + B, rand_forest(mode = "classification")) %>%
    fit(bivariate_train)

v <- vetiver_model(ranger_fit, "biv-rf")

b <- board_temp()
b %>% vetiver_pin_write(v, check_renv = TRUE)
#> Creating new version '20230407T172359Z-f060b'
#> Writing to pin 'biv-rf'
#> 
#> Create a Model Card for your published model
#> • Model Cards provide a framework for transparent, responsible reporting
#> • Use the vetiver `.Rmd` template as a place to start

out <- b %>% vetiver_pin_read("biv-rf", check_renv = TRUE)
```

<sup>Created on 2023-04-07 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>