### PR TITLE
Add new endpoint for metadata

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -104,6 +104,11 @@ vetiver_pr_post <- function(pr,
             function() vetiver_model$metadata$url
         )
     }
+    pr <- plumber::pr_get(
+        pr,
+        path = "/metadata",
+        function() vetiver_model$metadata
+    )
     if (!check_prototype) {
         vetiver_model$prototype <- NULL
     }
@@ -112,7 +117,7 @@ vetiver_pr_post <- function(pr,
         path = path,
         handler = handler_predict(vetiver_model, ...)
     )
-
+    pr
 }
 
 #' @rdname vetiver_api

--- a/R/open-api-spec.R
+++ b/R/open-api-spec.R
@@ -137,6 +137,9 @@ api_spec <- function(spec, vetiver_model, path, all_docs = TRUE) {
     if ("/pin-url" %in% names(spec$paths)) {
         spec$paths$`/pin-url`$get$summary <- "Get URL of pinned vetiver model"
     }
+    if ("/metadata" %in% names(spec$paths)) {
+        spec$paths$`/metadata`$get$summary <- "Get all metadata of pinned vetiver model"
+    }
     if ("/ping" %in% names(spec$paths)) {
         spec$paths$`/ping`$get$summary <- "Health check"
     }

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -17,3 +17,12 @@ redact_vetiver <- function(snapshot) {
 redact_port <- function(snapshot) {
     snapshot <- gsub(port, "<port>", snapshot, fixed = TRUE)
 }
+
+expect_api_routes <- function(routes) {
+    testthat::expect_equal(names(routes), c("metadata", "ping", "predict"))
+    testthat::expect_equal(
+        map_chr(routes, "verbs"),
+        c(metadata = "GET", ping = "GET", predict = "POST")
+    )
+}
+

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -3,9 +3,9 @@ library(plumber)
 
 test_that("default endpoint", {
     p <- pr() %>% vetiver_api(v)
-    expect_equal(names(p$routes), c("logo", "ping", "predict"))
+    expect_equal(names(p$routes), c("logo", "metadata", "ping", "predict"))
     expect_equal(map_chr(p$routes[-1], "verbs"),
-                 c(ping = "GET", predict = "POST"))
+                 c(metadata = "GET", ping = "GET", predict = "POST"))
 })
 
 test_that("old function is deprecated", {
@@ -22,9 +22,9 @@ test_that("default endpoint via modular functions", {
 test_that("pin URL endpoint", {
     v$metadata <- list(url = "potato")
     p <- pr() %>% vetiver_api(v)
-    expect_equal(names(p$routes), c("logo", "pin-url", "ping", "predict"))
+    expect_equal(names(p$routes), c("logo", "metadata", "pin-url", "ping", "predict"))
     expect_equal(map_chr(p$routes[-1], "verbs"),
-                 c(`pin-url` = "GET", ping = "GET", predict = "POST"))
+                 c(metadata = "GET", `pin-url` = "GET", ping = "GET", predict = "POST"))
 })
 
 test_that("default OpenAPI spec", {
@@ -39,9 +39,12 @@ test_that("default OpenAPI spec", {
                  list(type = "object",
                       properties = list(cyl = list(type = "number"),
                                         disp = list(type = "number"))))
-    get_spec <- car_spec$paths$`/pin-url`$get
-    expect_equal(as.character(get_spec$summary),
+    get_spec1 <- car_spec$paths$`/pin-url`$get
+    expect_equal(as.character(get_spec1$summary),
                  "Get URL of pinned vetiver model")
+    get_spec2 <- car_spec$paths$`/metadata`$get
+    expect_equal(as.character(get_spec2$summary),
+                 "Get all metadata of pinned vetiver model")
 
 })
 
@@ -60,9 +63,9 @@ test_that("OpenAPI spec for check_prototype = FALSE", {
     )
 
     p <- pr() %>% vetiver_pr_post(v, check_prototype = FALSE) %>% vetiver_pr_docs(v)
-    expect_equal(names(p$routes), c("logo", "ping", "predict"))
+    expect_equal(names(p$routes), c("logo", "metadata", "ping", "predict"))
     expect_equal(map_chr(p$routes[-1], "verbs"),
-                 c(ping = "GET", predict = "POST"))
+                 c(metadata = "GET", ping = "GET", predict = "POST"))
     car_spec <- p$getApiSpec()
     post_spec <- car_spec$paths$`/predict`$post
 
@@ -76,9 +79,9 @@ test_that("OpenAPI spec for check_prototype = FALSE", {
 test_that("OpenAPI spec for save_prototype = FALSE", {
     v1 <- vetiver_model(cars_lm, "cars1", save_prototype = FALSE)
     p <- pr() %>% vetiver_api(v1)
-    expect_equal(names(p$routes), c("logo", "ping", "predict"))
+    expect_equal(names(p$routes), c("logo", "metadata", "ping", "predict"))
     expect_equal(map_chr(p$routes[-1], "verbs"),
-                 c(ping = "GET", predict = "POST"))
+                 c(metadata = "GET", ping = "GET", predict = "POST"))
     car_spec <- p$getApiSpec()
     post_spec <- car_spec$paths$`/predict`$post
     expect_equal(names(post_spec), c("summary", "requestBody", "responses"))

--- a/tests/testthat/test-caret.R
+++ b/tests/testthat/test-caret.R
@@ -42,9 +42,7 @@ test_that("can pin a caret model", {
 test_that("default endpoint for caret", {
     p <- pr() %>% vetiver_api(v)
     p_routes <- p$routes[-1]
-    expect_equal(names(p_routes), c("ping", "predict"))
-    expect_equal(map_chr(p_routes, "verbs"),
-                 c(ping = "GET", predict = "POST"))
+    expect_api_routes(p_routes)
 })
 
 test_that("default OpenAPI spec", {

--- a/tests/testthat/test-gam.R
+++ b/tests/testthat/test-gam.R
@@ -37,9 +37,7 @@ test_that("can pin a gam model", {
 test_that("default endpoint for gam", {
     p <- pr() %>% vetiver_api(v)
     p_routes <- p$routes[-1]
-    expect_equal(names(p_routes), c("ping", "predict"))
-    expect_equal(map_chr(p_routes, "verbs"),
-                 c(ping = "GET", predict = "POST"))
+    expect_api_routes(p_routes)
 })
 
 test_that("default OpenAPI spec", {

--- a/tests/testthat/test-glm.R
+++ b/tests/testthat/test-glm.R
@@ -36,9 +36,7 @@ test_that("can pin a glm model", {
 test_that("default endpoint for glm", {
     p <- pr() %>% vetiver_api(v)
     p_routes <- p$routes[-1]
-    expect_equal(names(p_routes), c("ping", "predict"))
-    expect_equal(map_chr(p_routes, "verbs"),
-                 c(ping = "GET", predict = "POST"))
+    expect_api_routes(p_routes)
 })
 
 test_that("default OpenAPI spec", {

--- a/tests/testthat/test-keras.R
+++ b/tests/testthat/test-keras.R
@@ -53,9 +53,7 @@ test_that("can pin a keras model", {
 test_that("default endpoint for keras", {
     p <- pr() %>% vetiver_api(v)
     p_routes <- p$routes[-1]
-    expect_equal(names(p_routes), c("ping", "predict"))
-    expect_equal(map_chr(p_routes, "verbs"),
-                 c(ping = "GET", predict = "POST"))
+    expect_api_routes(p_routes)
 })
 
 test_that("default OpenAPI spec", {

--- a/tests/testthat/test-kproto.R
+++ b/tests/testthat/test-kproto.R
@@ -42,9 +42,7 @@ test_that("can pin a kproto model", {
 test_that("default endpoint for kproto", {
     p <- plumber::pr() %>% vetiver_api(v)
     p_routes <- p$routes[-1]
-    expect_equal(names(p_routes), c("ping", "predict"))
-    expect_equal(purrr::map_chr(p_routes, "verbs"),
-                 c(ping = "GET", predict = "POST"))
+    expect_api_routes(p_routes)
 })
 
 test_that("default OpenAPI spec", {

--- a/tests/testthat/test-predict.R
+++ b/tests/testthat/test-predict.R
@@ -17,6 +17,13 @@ test_that("router has health check endpoint", {
     expect_equal(r$status_code, 200)
 })
 
+test_that("router has metadata endpoint", {
+    r <- httr::GET(root_path, port = port, path = "metadata")
+    metadata <- jsonlite::fromJSON(httr::content(r, as = "text", encoding = "UTF-8"))
+    expect_equal(r$status_code, 200)
+    expect_equal(names(metadata), c("user", "version", "url", "required_pkgs"))
+})
+
 test_that("can predict on basic vetiver router", {
     endpoint <- vetiver_endpoint(paste0(root_path, ":", port, "/predict"))
     expect_s3_class(endpoint, "vetiver_endpoint")

--- a/tests/testthat/test-ranger.R
+++ b/tests/testthat/test-ranger.R
@@ -39,9 +39,7 @@ test_that("can pin an ranger model", {
 test_that("default endpoint for ranger", {
     p <- pr() %>% vetiver_api(v)
     p_routes <- p$routes[-1]
-    expect_equal(names(p_routes), c("ping", "predict"))
-    expect_equal(map_chr(p_routes, "verbs"),
-                 c(ping = "GET", predict = "POST"))
+    expect_api_routes(p_routes)
 })
 
 test_that("default OpenAPI spec", {

--- a/tests/testthat/test-recipe.R
+++ b/tests/testthat/test-recipe.R
@@ -35,9 +35,7 @@ test_that("can pin a recipe", {
 test_that("default endpoint for recipe", {
     p <- pr() %>% vetiver_api(v)
     p_routes <- p$routes[-1]
-    expect_equal(names(p_routes), c("ping", "predict"))
-    expect_equal(map_chr(p_routes, "verbs"),
-                 c(ping = "GET", predict = "POST"))
+    expect_api_routes(p_routes)
 })
 
 test_that("default OpenAPI spec", {

--- a/tests/testthat/test-tidymodels.R
+++ b/tests/testthat/test-tidymodels.R
@@ -48,9 +48,7 @@ test_that("can pin a tidymodels model", {
 test_that("default endpoint for tidymodels", {
     p <- pr() %>% vetiver_api(v)
     p_routes <- p$routes[-1]
-    expect_equal(names(p_routes), c("ping", "predict"))
-    expect_equal(map_chr(p_routes, "verbs"),
-                 c(ping = "GET", predict = "POST"))
+    expect_api_routes(p_routes)
 })
 
 test_that("default OpenAPI spec", {

--- a/tests/testthat/test-xgboost.R
+++ b/tests/testthat/test-xgboost.R
@@ -39,9 +39,7 @@ test_that("can pin an xgboost model", {
 test_that("default endpoint for xgboost", {
     p <- pr() %>% vetiver_api(v)
     p_routes <- p$routes[-1]
-    expect_equal(names(p_routes), c("ping", "predict"))
-    expect_equal(map_chr(p_routes, "verbs"),
-                 c(ping = "GET", predict = "POST"))
+    expect_api_routes(p_routes)
 })
 
 test_that("default OpenAPI spec", {


### PR DESCRIPTION
Related to rstudio/vetiver-python#170

``` r
library(vetiver)
cars_lm <- lm(mpg ~ ., data = mtcars)
v <- vetiver_model(cars_lm, "cars_linear")

library(plumber)
pr() %>% vetiver_api(v)
#> # Plumber router with 3 endpoints, 4 filters, and 1 sub-router.
#> # Use `pr_run()` on this object to start the API.
#> ├──[queryString]
#> ├──[body]
#> ├──[cookieParser]
#> ├──[sharedSecret]
#> ├──/logo
#> │  │ # Plumber static router serving from directory: /Library/Frameworks/R.framework/Versions/4.2-arm64/Resources/library/vetiver
#> ├──/metadata (GET)
#> ├──/ping (GET)
#> └──/predict (POST)
```

<sup>Created on 2023-04-13 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>