### PR TITLE
Update tests for new version of pins

### DIFF
--- a/tests/testthat/test-choose-version.R
+++ b/tests/testthat/test-choose-version.R
@@ -1,14 +1,19 @@
 test_that("can choose a version", {
-    b <- board_temp()
+    skip_on_cran()
+    b <- board_temp(versioned = TRUE)
+    mock_version_name <- mockery::mock(
+        "20130104T050607Z-xxxxx",
+        "20130204T050607Z-yyyyy",
+        "20130304T050607Z-zzzzz",
+    )
+    local_mocked_bindings(version_name = mock_version_name, .package = "pins")
     cars_lm <- lm(mpg ~ cyl + disp, data = mtcars)
     v <- vetiver_model(cars_lm, "cars1")
     vetiver_pin_write(b, v)
-    Sys.sleep(0.5)
     vetiver_pin_write(b, v)
-    Sys.sleep(0.5)
     vetiver_pin_write(b, v)
     p <- pins::pin_versions(b, "cars1")
-    expect_equal(p$version[[1]], choose_version(p))
+    expect_equal(p$version[[3]], choose_version(p))
 })
 
 test_that("can choose a version by `active` column like on Connect", {

--- a/tests/testthat/test-sagemaker.R
+++ b/tests/testthat/test-sagemaker.R
@@ -7,6 +7,7 @@ test_that("can deploy via `vetiver_deploy_sagemaker()`", {
     mockery::stub(vetiver_deploy_sagemaker, "vetiver_sm_build", "new_sagemaker_uri")
     mockery::stub(vetiver_deploy_sagemaker, "vetiver_sm_model", model_name)
     mockery::stub(vetiver_deploy_sagemaker, "vetiver_sm_endpoint", vetiver_endpoint_sagemaker(model_name))
+    local_mocked_bindings(version_name = function(metadata) "20130102T050607Z-xxxxx", .package = "pins")
 
     b <- board_folder(path = tmp_dir)
     cars_lm <- lm(mpg ~ cyl + disp, data = mtcars)
@@ -23,6 +24,7 @@ test_that("can deploy via `vetiver_deploy_sagemaker()`", {
 test_that("can create correct files for `vetiver_sm_build()`", {
     skip_on_cran()
     mockery::stub(vetiver_sm_build, "smdocker::sm_build", "new_sagemaker_uri")
+    local_mocked_bindings(version_name = function(metadata) "20130202T050607Z-xxxxx", .package = "pins")
 
     b <- board_folder(path = tmp_dir)
     cars_lm <- lm(mpg ~ cyl + disp, data = mtcars)

--- a/tests/testthat/test-write-plumber.R
+++ b/tests/testthat/test-write-plumber.R
@@ -3,6 +3,7 @@ skip_if_not_installed("plumber")
 test_that("create plumber.R with no packages", {
     skip_on_cran()
     b <- board_folder(path = tmp_dir)
+    local_mocked_bindings(version_name = function(metadata) "20130104T050607Z-xxxxx", .package = "pins")
     tmp <- tempfile()
     vetiver_pin_write(b, v)
     vetiver_write_plumber(b, "cars1", file = tmp)
@@ -15,6 +16,7 @@ test_that("create plumber.R with no packages", {
 test_that("create plumber.R with packages", {
     skip_on_cran()
     b <- board_folder(path = tmp_dir)
+    local_mocked_bindings(version_name = function(metadata) "20130204T050607Z-xxxxx", .package = "pins")
     tmp <- tempfile()
     v$metadata$required_pkgs <- c("beepr", "janeaustenr")
     vetiver_pin_write(b, v)
@@ -28,6 +30,7 @@ test_that("create plumber.R with packages", {
 test_that("create plumber.R with rsconnect = FALSE", {
     skip_on_cran()
     b <- board_folder(path = tmp_dir)
+    local_mocked_bindings(version_name = function(metadata) "20130304T050607Z-xxxxx", .package = "pins")
     tmp <- tempfile()
     v$metadata$required_pkgs <- c("beepr", "janeaustenr")
     vetiver_pin_write(b, v)
@@ -41,6 +44,7 @@ test_that("create plumber.R with rsconnect = FALSE", {
 test_that("create plumber.R with args in dots", {
     skip_on_cran()
     b <- board_folder(path = tmp_dir)
+    local_mocked_bindings(version_name = function(metadata) "20130404T050607Z-xxxxx", .package = "pins")
     tmp <- tempfile()
     v$metadata$required_pkgs <- c("beepr", "janeaustenr")
     vetiver_pin_write(b, v)


### PR DESCRIPTION
In pins, I recently made some major improvements to the testing strategy. Those changes will cause some problems for the tests here in vetiver, requiring these changes in this PR. Probably vetiver should go to CRAN before pins.

There is one more snapshot change that will be needed after pins goes to CRAN but I don't want to change it now since vetiver will go to CRAN first:

```
Snapshot of `vetiver_pin_metrics(b, df_metrics, "metrics1", overwrite = TRUE)` has changed:
`lines(old)`: "Can't find pin called 'metrics1'"   "i Use `pin_list()` to see all available pins in this board"
`lines(new)`: "Can't find pin called \"metrics1\"" "i Use `pin_list()` to see all available pins in this board"
```