### PR TITLE
Document S3-specific pins board for SageMaker

### DIFF
--- a/R/sagemaker.R
+++ b/R/sagemaker.R
@@ -113,6 +113,8 @@ vetiver_deploy_sagemaker <- function(board,
 #' - `vetiver_sm_endpoint()` deploys an Amazon SageMaker model endpoint
 #'
 #' @inheritParams vetiver_prepare_docker
+#' @param board An AWS S3 board created with [pins::board_s3()]. This board
+#' must be in the correct region for your SageMaker instance.
 #' @param repository The ECR repository and tag for the image as a character.
 #' Defaults to `sagemaker-studio-${domain_id}:latest`.
 #' @param compute_type The [CodeBuild](https://aws.amazon.com/codebuild/)

--- a/man/vetiver_deploy_sagemaker.Rd
+++ b/man/vetiver_deploy_sagemaker.Rd
@@ -17,8 +17,8 @@ vetiver_deploy_sagemaker(
 )
 }
 \arguments{
-\item{board}{A pin board, created by \code{\link[pins:board_folder]{board_folder()}}, \code{\link[pins:board_connect]{board_connect()}},
-\code{\link[pins:board_url]{board_url()}} or another \code{board_} function.}
+\item{board}{An AWS S3 board created with \code{\link[pins:board_s3]{pins::board_s3()}}. This board
+must be in the correct region for your SageMaker instance.}
 
 \item{name}{Pin name.}
 

--- a/man/vetiver_sm_build.Rd
+++ b/man/vetiver_sm_build.Rd
@@ -49,8 +49,8 @@ vetiver_sm_endpoint(
 )
 }
 \arguments{
-\item{board}{A pin board, created by \code{\link[pins:board_folder]{board_folder()}}, \code{\link[pins:board_connect]{board_connect()}},
-\code{\link[pins:board_url]{board_url()}} or another \code{board_} function.}
+\item{board}{An AWS S3 board created with \code{\link[pins:board_s3]{pins::board_s3()}}. This board
+must be in the correct region for your SageMaker instance.}
 
 \item{name}{Pin name.}
 


### PR DESCRIPTION
You can't actually use any board at all when deploying to SageMaker.