### PR TITLE
Update pkgdown navbar

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -2,14 +2,15 @@ template:
   bootstrap: 5
   package: tidytemplate
 
+
 navbar:
+  structure:
+    left:  [intro, reference, news, vetiver]
   components:
-    home: ~
-    tutorials:
-      text: Learn more
-      menu:
-      - text: "Model Cards for transparent, responsible reporting"
-        href: https://vetiver.rstudio.com/learn-more/model-card.html
+    vetiver:
+      text: Learn more about vetiver
+      href: https://vetiver.rstudio.com
+
 
 development:
   mode: auto

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -2,14 +2,17 @@ template:
   bootstrap: 5
   package: tidytemplate
 
-
 navbar:
   structure:
     left:  [intro, reference, news, vetiver]
   components:
     vetiver:
-      text: Learn more about vetiver
-      href: https://vetiver.rstudio.com
+      text: Learn more
+      menu:
+        - text: "vetiver.rstudio.com"
+          href: https://vetiver.rstudio.com
+        - text: "Python package documentation"
+          href: https://rstudio.github.io/vetiver-python/
 
 
 development:


### PR DESCRIPTION
We had discussion this week that it would be good to have an additional link to https://vetiver.studio.com on the navbar. I also think it would be good to add a more prominent link to the Python docs.

@isabelizimm here is what I ended up doing! I think "Learn more" is probably a better option that something about "main site" (although I know we say that a lot internally). I bet you can do [this kind of navbar with Quarto](https://quarto.org/docs/websites/website-navigation.html), right?