### PR TITLE
Verify that `plumber_file` exists before creating Dockerfile

### DIFF
--- a/R/write-docker.R
+++ b/R/write-docker.R
@@ -64,6 +64,16 @@ vetiver_write_docker <- function(vetiver_model,
                                  additional_pkgs = character(0)) {
 
     ellipsis::check_dots_empty()
+    
+    if (!fs::file_exists(plumber_file)) {
+      cli::cli_abort(
+        c(
+          "{.arg plumber_file} does not exist at {.path {plumber_file}}",
+          "i" = "Create your Plumber file with {.fn vetiver_write_plumber}"
+          )
+        )
+    }
+    
     withr::local_options(list(renv.dynamic.enabled = FALSE))
 
     rspm_env <- ifelse(


### PR DESCRIPTION

Currently there is no check to see if the `plumber_file` argument leads to a real plumber file. It is possible to create a Dockerfile with a non-existent plumber file at present. See reprex below. 

This PR adds a check to verify that the plumber file does indeed exist. 

``` r
library(vetiver)
cars_lm <- lm(mpg ~ ., data = mtcars)
v <- vetiver_model(cars_lm, "cars_linear")

dir.create("inst/vetiver", recursive = TRUE)
vetiver_write_docker(v, path = "inst/vetiver")
#> The version of R recorded in the lockfile will be updated:
#> - R             [* -> 4.3.0]
#> 
#> * Lockfile written to 'vetiver_renv.lock'.

list.files("inst/vetiver")
#> [1] "Dockerfile"
list.files()
#> [1] "inst" "vetiver_renv.lock"
```