### PR TITLE
Fixed typo in the docs for the `role` arg in `vetiver_sm_build()`

### DIFF
--- a/R/sagemaker.R
+++ b/R/sagemaker.R
@@ -119,7 +119,7 @@ vetiver_deploy_sagemaker <- function(board,
 #' Defaults to `sagemaker-studio-${domain_id}:latest`.
 #' @param compute_type The [CodeBuild](https://aws.amazon.com/codebuild/)
 #' compute type as a character. Defaults to `BUILD_GENERAL1_SMALL`.
-#' @param role The ARM IAM role name (as a character) to be used with:
+#' @param role The ARN IAM role name (as a character) to be used with:
 #' - CodeBuild for `vetiver_sm_build()`
 #' - the SageMaker model for `vetiver_sm_model()`
 #'

--- a/man/vetiver_sm_build.Rd
+++ b/man/vetiver_sm_build.Rd
@@ -74,7 +74,7 @@ Defaults to \verb{sagemaker-studio-$\{domain_id\}:latest}.}
 \item{compute_type}{The \href{https://aws.amazon.com/codebuild/}{CodeBuild}
 compute type as a character. Defaults to \code{BUILD_GENERAL1_SMALL}.}
 
-\item{role}{The ARM IAM role name (as a character) to be used with:
+\item{role}{The ARN IAM role name (as a character) to be used with:
 \itemize{
 \item CodeBuild for \code{vetiver_sm_build()}
 \item the SageMaker model for \code{vetiver_sm_model()}


### PR DESCRIPTION
Addresses the typo mentioned in https://github.com/rstudio/vetiver-r/issues/215