### PR TITLE
Changing `board_rsconnect()` to `board_connect()` as the former was deprecated in pins 1.1.0.

### DIFF
--- a/inst/netflix_tidymodels.R
+++ b/inst/netflix_tidymodels.R
@@ -35,7 +35,7 @@ v <- vetiver_model(netflix_fit, "netflix_descriptions")
 v
 
 library(pins)
-model_board <- board_rsconnect()
+model_board <- board_connect()
 vetiver_pin_write(model_board, v)
 
 library(plumber)

--- a/inst/rmarkdown/templates/vetiver_model_card/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/vetiver_model_card/skeleton/skeleton.Rmd
@@ -4,7 +4,7 @@ date: '`r Sys.Date()`'
 output: 
   html_document
 params:
-    board: !r pins::board_rsconnect()
+    board: !r pins::board_connect()
     name: julia.silge/sacramento-rf
     version: NULL
 ---

--- a/vignettes/vetiver.Rmd
+++ b/vignettes/vetiver.Rmd
@@ -112,7 +112,7 @@ vetiver_write_plumber(model_board, "biv_svm", file = tmp)
 cat(readr::read_lines(tmp), sep = "\n")
 ```
 
-In a real-world situation, you would see something like `b <- board_rsconnect()` or `b <- board_s3()` here instead of our temporary demo board. Notice that the deployment is strongly linked to a *specific version* of the pinned model; if you pin another version of the model after you deploy your model, your deployed model will not be affected.
+In a real-world situation, you would see something like `b <- board_connect()` or `b <- board_s3()` here instead of our temporary demo board. Notice that the deployment is strongly linked to a *specific version* of the pinned model; if you pin another version of the model after you deploy your model, your deployed model will not be affected.
 
 ## Predict from your model endpoint
 


### PR DESCRIPTION
Addresses https://github.com/rstudio/vetiver-r/issues/188 and related to https://github.com/rstudio/pins-r/issues/678