### PR TITLE
Add `appName` example to dots

### DIFF
--- a/R/rsconnect.R
+++ b/R/rsconnect.R
@@ -10,7 +10,7 @@
 #' @param appTitle The API title on Posit Connect. Use the default based on
 #' `name`, or pass in your own title.
 #' @param ... Other arguments passed to [rsconnect::deployApp()] such as
-#' `account` or `launch.browser`.
+#' `appName`, `account`, or `launch.browser`.
 #'
 #' @details The two functions `vetiver_deploy_rsconnect()` and
 #' [vetiver_create_rsconnect_bundle()] are alternatives to each other, providing

--- a/man/vetiver_deploy_rsconnect.Rd
+++ b/man/vetiver_deploy_rsconnect.Rd
@@ -29,7 +29,7 @@ such as the prediction \code{type}.}
 \code{name}, or pass in your own title.}
 
 \item{...}{Other arguments passed to \code{\link[rsconnect:deployApp]{rsconnect::deployApp()}} such as
-\code{account} or \code{launch.browser}.}
+\code{appName}, \code{account}, or \code{launch.browser}.}
 }
 \value{
 The deployment success (\code{TRUE} or \code{FALSE}), invisibly.

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,7 +1,6 @@
 options(pins.verbose = FALSE)
 options(pins.quiet = TRUE)
 options(renv.verbose = FALSE)
-Sys.setenv(RENV_CONFIG_SNAPSHOT_VALIDATE = FALSE)
 
 clean_python_tmp_dir <- function() {
     if (rlang::is_installed("reticulate")) {

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,6 +1,7 @@
 options(pins.verbose = FALSE)
 options(pins.quiet = TRUE)
 options(renv.verbose = FALSE)
+Sys.setenv(RENV_CONFIG_SNAPSHOT_VALIDATE = FALSE)
 
 clean_python_tmp_dir <- function() {
     if (rlang::is_installed("reticulate")) {


### PR DESCRIPTION
For Posit Connect, it will be helpful to give folks a little more hinting around the difference between `appName` and `appTitle`. I do think it's the _title_ that we want to set up with some nice automated treatment (rather than the name) but folks have gotten confused.

More on these arguments here:
https://rstudio.github.io/rsconnect/reference/deployApp.html