### PR TITLE
Use development versions of renv + rsconnect

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,9 @@ Imports:
     purrr,
     rapidoc,
     readr (>= 1.4.0),
+    renv (>= 1.0.0),
     rlang (>= 1.1.0),
+    rsconnect (>= 1.0.1),
     tibble,
     vctrs,
     withr
@@ -70,7 +72,6 @@ Suggests:
     reticulate,
     rmarkdown,
     rpart,
-    rsconnect,
     slider (>= 0.2.2),
     smdocker (>= 0.1.2),
     stacks,
@@ -89,3 +90,6 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
+Remotes:  
+    rstudio/rsconnect,
+    rstudio/renv


### PR DESCRIPTION
Trying to learn more about `rsconnect::writeManifest()` failure