### PR TITLE
Mock `rsconnect::writeManifest()` in test

### DIFF
--- a/R/rsconnect.R
+++ b/R/rsconnect.R
@@ -125,3 +125,7 @@ vetiver_create_rsconnect_bundle <- function(
     invisible(filename)
 
 }
+
+mock_write_manifest <- function(appDir, appFiles) {
+    fs::file_create(fs::path(appDir, "manifest.json"))
+}

--- a/tests/testthat/test-rsconnect.R
+++ b/tests/testthat/test-rsconnect.R
@@ -1,6 +1,7 @@
 skip_if_not_installed("rsconnect")
 
 describe("create rsconnect bundle", {
+    local_mocked_bindings(writeManifest = mock_write_manifest, .package = "rsconnect")
     tar_file <- fs::file_temp(pattern = "bundle", tmp_dir = tmp_dir, ext = ".tar.gz")
 
     b <- board_folder(path = tmp_dir)


### PR DESCRIPTION
Recent releases of renv + rsconnect have caused some problems for this Connect test, since we can't make a manifest that is actually deployable with a source installation of vetiver. Let's see if this will fix it. 🤞 