### PR TITLE
Use base R `deparse()` when writing `plumber.R`

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -52,7 +52,8 @@ jobs:
           extra-packages:
             any::rcmdcheck,
             any::cpp11,
-            ranger=?ignore-before-r=4.1.0
+            ranger=?ignore-before-r=4.1.0,
+            vdiffr@1.0.5
           needs: check
 
       - name: Install Miniconda & Tensorflow

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # vetiver (development version)
 
+* Fixed how plumber files are generated for `board_url()` (#241).
+
 # vetiver 0.2.3
 
 * Updated test involving renv and rsconnect (#230).

--- a/R/write-plumber.R
+++ b/R/write-plumber.R
@@ -59,7 +59,7 @@ vetiver_write_plumber <- function(board, name, version = NULL,
     load_infra_pkgs <- glue_collapse(glue("library({infra_pkgs})"), sep = "\n")
     load_required_pkgs <- glue_required_pkgs(v$metadata$required_pkgs, rsconnect)
 
-    board <- rlang::expr_deparse(pins::board_deparse(board))
+    board <- deparse(pins::board_deparse(board))
     board <- glue('b <- {board}')
 
     if (rlang::is_empty(plumber_dots)) {


### PR DESCRIPTION
Closes #239 

With this change, I now can correctly generate code for a `board_url()`.

``` r
library(pins)
b <- board_url(c(
  chicago_model = 'https://colorado.posit.co/rsc/chicago-rstats-model-pin/'
))

deparse(board_deparse(b))
#> [1] "board_url(c(chicago_model = \"https://colorado.posit.co/rsc/chicago-rstats-model-pin/\"))"
```

<sup>Created on 2023-09-07 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>