### PR TITLE
Go back to `rlang::expr_deparse()` except for `board_url()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # vetiver (development version)
 
+* Fixed bug in generating plumber files (#257).
+
 # vetiver 0.2.4
 
 * Fixed how plumber files are generated for `board_url()` (#241).

--- a/R/write-plumber.R
+++ b/R/write-plumber.R
@@ -59,7 +59,13 @@ vetiver_write_plumber <- function(board, name, version = NULL,
     load_infra_pkgs <- glue_collapse(glue("library({infra_pkgs})"), sep = "\n")
     load_required_pkgs <- glue_required_pkgs(v$metadata$required_pkgs, rsconnect)
 
-    board <- deparse(pins::board_deparse(board))
+    ## rlang::expr_deparse won't work for board_url, but
+    ## base deparse won't work for S3 and other complex boards:
+    if (inherits(board, "pins_board_url")) {
+        board <- deparse(pins::board_deparse(board))
+    } else {
+        board <- rlang::expr_deparse(pins::board_deparse(board))
+    }
     board <- glue('b <- {board}')
 
     if (rlang::is_empty(plumber_dots)) {


### PR DESCRIPTION
Addresses these user-reported issues:

- #253 
- #256 

The change in #241 turned out to actually break generating the plumber files for more complex boards like S3 and similar. 😩 

I need to think about testing across different board types in vetiver. The pins package is tested very extensively across all the backends but vetiver does not, and here it is the code that _vetiver_ ran that was the problem. I could probably get away with mocking `vetiver_pin_read()` in such tests to avoid needing to call S3 like pins CI does.