### PR TITLE
refactor: change task_prototype to data_prototype

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,7 +55,7 @@ Suggests:
     LiblineaR,
     luz,
     mgcv,
-    mlr3,
+    mlr3 (>= 0.17.0),
     mlr3data,
     mlr3learners,
     mockery,

--- a/R/mlr3.R
+++ b/R/mlr3.R
@@ -15,7 +15,7 @@ vetiver_create_meta.Learner <- function(model, metadata) {
 #' @rdname vetiver_create_ptype
 #' @export
 vetiver_ptype.Learner <- function(model, ...) {
-    tibble::as_tibble(model$state$task_prototype)[, model$state$train_task$feature_names]
+    tibble::as_tibble(model$state$data_prototype)[, model$state$train_task$feature_names]
 }
 
 #' @rdname vetiver_create_description


### PR DESCRIPTION
We want to remove`$task_prototype` in mlr3 and use  `$data_prototype` instead. Both will be available for some time.