### PR TITLE
When a recipe has a `ptype`, use it to set up the vetiver model

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -65,7 +65,7 @@ Suggests:
     plotly,
     plumber (>= 1.0.0),
     ranger,
-    recipes,
+    recipes (>= 1.1.0),
     reticulate,
     rmarkdown,
     rpart,

--- a/R/recipe.R
+++ b/R/recipe.R
@@ -16,11 +16,17 @@ vetiver_create_meta.recipe <- function(model, metadata) {
 #' @rdname vetiver_create_ptype
 #' @export
 vetiver_ptype.recipe <- function(model, ...) {
-    rlang::check_dots_used()
-    dots <- list(...)
-    check_ptype_data(dots)
-    ptype <- vctrs::vec_ptype(dots$prototype_data)
-    tibble::as_tibble(ptype)
+    ptype <- model$ptype
+    if (is_null(ptype)) {
+        rlang::check_dots_used()
+        dots <- list(...)
+        check_ptype_data(dots)
+        ptype <- vctrs::vec_ptype(dots$prototype_data)
+        return(tibble::as_tibble(ptype))
+    }
+    preds <- vec_slice(model$var_info, model$var_info$role == "predictor")
+    preds <- preds$variable
+    ptype[preds]
 }
 
 #' @rdname vetiver_create_description

--- a/R/recipe.R
+++ b/R/recipe.R
@@ -16,8 +16,7 @@ vetiver_create_meta.recipe <- function(model, metadata) {
 #' @rdname vetiver_create_ptype
 #' @export
 vetiver_ptype.recipe <- function(model, ...) {
-    preds <- vec_slice(model$var_info, model$var_info$role == "predictor")
-    model$ptype[preds$variable]
+    recipes::recipes_ptype(model, stage = "bake")
 }
 
 #' @rdname vetiver_create_description

--- a/R/recipe.R
+++ b/R/recipe.R
@@ -16,17 +16,8 @@ vetiver_create_meta.recipe <- function(model, metadata) {
 #' @rdname vetiver_create_ptype
 #' @export
 vetiver_ptype.recipe <- function(model, ...) {
-    ptype <- model$ptype
-    if (is_null(ptype)) {
-        rlang::check_dots_used()
-        dots <- list(...)
-        check_ptype_data(dots)
-        ptype <- vctrs::vec_ptype(dots$prototype_data)
-        return(tibble::as_tibble(ptype))
-    }
     preds <- vec_slice(model$var_info, model$var_info$role == "predictor")
-    preds <- preds$variable
-    ptype[preds]
+    model$ptype[preds$variable]
 }
 
 #' @rdname vetiver_create_description

--- a/tests/testthat/test-recipe.R
+++ b/tests/testthat/test-recipe.R
@@ -1,4 +1,4 @@
-skip_if_not_installed("recipes", "1.1.0")
+skip_if_not_installed("recipes")
 skip_if_not_installed("plumber")
 
 library(plumber)

--- a/tests/testthat/test-recipe.R
+++ b/tests/testthat/test-recipe.R
@@ -1,4 +1,4 @@
-skip_if_not_installed("recipes")
+skip_if_not_installed("recipes", "1.1.0")
 skip_if_not_installed("plumber")
 
 library(plumber)
@@ -9,7 +9,7 @@ trained_rec <-
     step_ns(wt) %>%
     prep(retain = FALSE)
 
-v <- vetiver_model(trained_rec, "car-splines", prototype_data = mtcars[c("disp", "wt")])
+v <- vetiver_model(trained_rec, "car-splines")
 
 test_that("can print recipe", {
     expect_snapshot(v)


### PR DESCRIPTION
Closes #286 

~~The recipes tests now skip on older versions but I didn't bump in `DESCRIPTION`. Maybe I should just bump though, actually.~~

I did decide to bump the version for recipes in `DESCRIPTION`; I think that's better than trying to support both moving forward.