### PR TITLE
Add xgboost check

### DIFF
--- a/tests/testthat/test-mlr3.R
+++ b/tests/testthat/test-mlr3.R
@@ -28,6 +28,7 @@ test_that("mlr3 learners can be pinned", {
 
 test_that("learners from mlr3learners can be pinned", {
     skip_if_not_installed("mlr3learners")
+    skip_if_not_installed("xgboost")
 
     task =  mlr3::tsk("spam")
     learner = mlr3learners::LearnerClassifXgboost$new()


### PR DESCRIPTION
Adds a skip when `xgboost` is not installed. Otherwise, test will fail with:

```r
── Error ('test-mlr3.R:34:5'): learners from mlr3learners can be pinned ────────
<packageNotFoundError/error/condition>
Error: The following packages could not be loaded: xgboost
Backtrace:
    ▆
 1. └─learner$train(task) at test-mlr3.R:34:5
 2.   └─mlr3:::.__Learner__train(...)
 3.     └─mlr3:::learner_train(...)
 4.       └─mlr3misc::require_namespaces(learner$packages)
```
